### PR TITLE
Allow custom options to be passed to request()

### DIFF
--- a/module.js
+++ b/module.js
@@ -1,16 +1,28 @@
 var request = require("request");
 var http = require('http');
 
-function expand(shortUrl, callback) {
-	var pool = new http.Agent({'maxSockets': Infinity});
-    request( { 
+function expand(shortUrl, options, callback) {
+    // options are optional, the function can still be used like this: expand(shortUrl, callback)
+    if(typeof options == 'function') {
+        callback = options;
+        options = {};
+    }
+
+    var defaultOptions = { 
     	method: "HEAD"
       , url: shortUrl
       , followAllRedirects: true
       , timeout: 10000
       , pool: pool
-	},
-    function (error, response) {
+	};
+
+    // merge the user-supplied options with the default options
+    for(var attribute in options) {
+        defaultOptions[attribute] = options[attribute];
+    }
+
+	var pool = new http.Agent({'maxSockets': Infinity});
+    request(defaultOptions, function (error, response) {
         if (error) {
             callback(error);
         } else {

--- a/test/test.js
+++ b/test/test.js
@@ -15,5 +15,15 @@ describe('expand-url', function(){
 			done();
       });
     });
+
+    // test custom options
+    it('Expand http://goo.gl/siv9G7', function(done){
+      urlExpander.expand("http://google.com", {
+            url: "http://goo.gl/siv9G7"
+      }, function(err, longUrl){
+			longUrl.should.equal("http://timesmachine.nytimes.com/timesmachine/1970/03/03/78101709.html");
+			done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This allows the user to pass custom options to the request library such as HTTP Headers.

The expand() function can now be used in two ways:

``` javascript
expand(shortURL, callback);
// or
expand(shortURL, options, callback);
```

I also added a test which overrides the 'url' option.
